### PR TITLE
Fix #1 should not exclude hard paths with dotfiles in them.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ module.exports = function (opts) {
       opts.dot = true;
     }
 
-    var isDotfile = file.isDotfile() && file.relative !== '.git';
-    var isDotdir = file.isDotdir() || file.relative === '.git';
+    var isDotfile = file.isDotfile(file.basename) && file.relative !== '.git';
+    var isDotdir = file.isDotdir(file.basename) || file.relative === '.git';
 
     // dotfiles
     if (isDotfile && (opts.dot === true || opts.dotfiles === true)) {


### PR DESCRIPTION
a glob such as ../.some/path/**/*.js becomes useless because it will always have a 'dotdir'.

This changes the code to only check file.isDotdir(file.basename) which is the name of the actual dir/file that's being checked instead of the whole path.
